### PR TITLE
Update link format to match slack's mrkdwn link formatting

### DIFF
--- a/slack.lua
+++ b/slack.lua
@@ -98,8 +98,7 @@ function SmallCaps(s)
 end
 
 function Link(s, src, tit)
-  return "<a href='" .. escape(src,true) .. "' title='" ..
-         escape(tit,true) .. "'>" .. s .. "</a>"
+  return "<" .. escape(src,true) .. "|" .. s .. ">"
 end
 
 function Image(s, src, tit)


### PR DESCRIPTION
Change link to match [slack's mrkdown link spec](https://api.slack.com/reference/surfaces/formatting#linking-urls)