### PR TITLE
Update list format to match slack mrkdwn spec

### DIFF
--- a/slack.lua
+++ b/slack.lua
@@ -180,7 +180,7 @@ end
 function OrderedList(items)
   local buffer = {}
   for _, item in pairs(items) do
-    table.insert(buffer, "* " .. item .. "")
+    table.insert(buffer, "- " .. item .. "")
   end
   return table.concat(buffer, "\n")
 end
@@ -301,7 +301,7 @@ end
 function BulletList(items)
   local buffer = {}
   for _, item in pairs(items) do
-    table.insert(buffer, "* " .. item)
+    table.insert(buffer, "- " .. item)
   end
   return table.concat(buffer, "\n") .. "\n"
 end


### PR DESCRIPTION
Update list formatting to match [slack's mrkdwn spec](https://api.slack.com/reference/surfaces/formatting#block-formatting)