### PR TITLE
Add missing SoftBreak function

### DIFF
--- a/slack.lua
+++ b/slack.lua
@@ -273,6 +273,9 @@ meta.__index =
 setmetatable(_G, meta)
 
 
+function SoftBreak()
+  return " "
+end
 
 function LineBreak()
   return "\n"


### PR DESCRIPTION
Without this SoftBreak function, pandoc emits a warning and any soft line breaks in the source end up getting concatenated.