### PR TITLE
Fixes for multiline text and inline code blocks

### DIFF
--- a/slack.lua
+++ b/slack.lua
@@ -273,6 +273,9 @@ meta.__index =
 setmetatable(_G, meta)
 
 
+function SoftBreak()
+  return " "
+end
 
 function LineBreak()
   return "\n"

--- a/slack.lua
+++ b/slack.lua
@@ -78,7 +78,7 @@ end
 -- Comments indicate the types of other variables.
 
 function Str(s)
-  return escape(s)
+  return s
 end
 
 function Space()

--- a/slack.lua
+++ b/slack.lua
@@ -294,7 +294,7 @@ function Strikeout(s)
 end
 
 function Code(s, attr)
-  return '```' .. s .. '```'
+  return '`' .. s .. '`'
 end
 
 function Header(lev, s, attr)

--- a/slack.lua
+++ b/slack.lua
@@ -98,8 +98,10 @@ function SmallCaps(s)
 end
 
 function Link(s, src, tit)
-  return "<a href='" .. escape(src,true) .. "' title='" ..
-         escape(tit,true) .. "'>" .. s .. "</a>"
+-- slack doc (https://api.slack.com/reference/surfaces/formatting#linking-urls)
+-- says this works but it doesn't:
+-- return "<" .. escape(src,true) .. "|" .. s .. ">"
+  return escape(src,true)
 end
 
 function Image(s, src, tit)


### PR DESCRIPTION
Hi. Thanks for creating and publishing this.

I'm not sure if these things are issues for you, but I made these changes for my Slack client (Slack's mac desktop client)

1. The Slack client wasn't reversing escaped symbols in plain strings, so `<` was showing up in Slack as `&gt;`
2. multiline text blocks were being joined but the last word of a line was connected directly to the first word of the next line
3. inline code was being treated as code blocks
4. URLs were being written as HTML. I found a Slack doc that says how they want links formatted, but it didn't, so I just include the links directly.